### PR TITLE
Supporting pub on heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a Heroku buildpack for [Dart](http://www.dartlang.org/).
 
+Installation of packages through [pub](http://pub.dartlang.org/) is supported.
+
 ## Getting Started
 
 ```bash
@@ -15,7 +17,12 @@ $> git push heroku master
 -----> Heroku receiving push
 -----> Fetching custom buildpack... done
 -----> Dart app detected
------> Installing latest Dart VM
+-----> Installing Dart VM, build: latest
+-----> Copy Dart binaries to app root
+-----> Install packages
+.
+[...]
+.
 -----> Discovering process types
        Procfile declares types -> web
 -----> Compiled slug size is 10.5MB
@@ -23,6 +30,21 @@ $> git push heroku master
 
 $> curl http://myapp_name.herokuapp.com/
 ```
+
+## Configuration
+You can specify the version of the dart-sdk that should be used by
+
+```bash
+$> heroku config:set BUILD=<version number>
+```
+A list of versions can be found [here](http://commondatastorage.googleapis.com/dart-editor-archive-integration/latest/changelog.html)
+
+In order for the build version to come through in to the build pack you also need to set an experimental flag on Heroku
+
+```bash
+$> heroku labs:enable user-env-compile
+```
+More info on that can be found in [Heroku's Devcenter: Heroku Labs: user-env-compile](https://devcenter.heroku.com/articles/labs-user-env-compile)
 
 See `test-app` directory for the world simplest Dart web app running on Heroku: [dartvm.herokuapp.com](http://dartvm.herokuapp.com/)
 

--- a/bin/compile
+++ b/bin/compile
@@ -10,21 +10,54 @@ mkdir -p "$1" "$2"
 BUILD_DIR=$(cd "$1/" && pwd)
 CACHE_DIR=$(cd "$2/" && pwd)
 
+# the directory in which the packages will be stored
+PACKAGES_DIR="tmp/repo.git/.cache"
+
+# this variable is used by pub to determine the package install location
+PUB_CACHE="$CACHE_DIR/pub-cache"
+export PUB_CACHE
+
+
 function message {
   echo "$1"
   sync
 }
 
-DART_SDK_URL="http://commondatastorage.googleapis.com/dart-editor-archive-integration/latest/dartsdk-linux-64.tar.gz"
+# if no build number is set, download latest
+if [ -z "$BUILD" ]; then
+    BUILD="latest"
+fi
 
-#if [ ! -e "$CACHE_DIR/dart" ]; then
-  message "-----> Installing latest Dart VM"
+DART_SDK_URL="http://commondatastorage.googleapis.com/dart-editor-archive-integration/$BUILD/dartsdk-linux-64.tar.gz"
 
-  cd $CACHE_DIR
-  curl -L $DART_SDK_URL -s -o - | tar xzf -
-#else
-#  message "-----> Using cached Dart VM"
-#fi
+cd $BUILD_DIR
+mkdir -p $PACKAGES_DIR
 
-mkdir -p $BUILD_DIR/bin
-cp $CACHE_DIR/dart-sdk/bin/dart $BUILD_DIR/bin/dart
+
+message "-----> Installing Dart VM, build: $BUILD"
+
+cd $CACHE_DIR
+curl -L $DART_SDK_URL -s -o - | tar xzf -
+
+
+message "-----> Copy Dart binaries to app root"
+
+cp -r $CACHE_DIR/dart-sdk $BUILD_DIR
+
+# we need to copy the sdk into the /app folder in order for the sdk libraries to be referenced correctly
+# reason being that the /tmp folder will be deleted after build, and /app resembles the location of the ready built app
+cp -r $CACHE_DIR/dart-sdk /app
+
+
+message "-----> Install packages"
+
+cd $BUILD_DIR
+
+#start pub from the /app folder to have correct symlink paths
+/app/dart-sdk/bin/pub install
+
+# move packages from cache directory into build directory
+cd $CACHE_DIR
+cp -r $CACHE_DIR/pub-cache $BUILD_DIR/$PACKAGES_DIR
+
+

--- a/test-app/Procfile
+++ b/test-app/Procfile
@@ -1,1 +1,1 @@
-web: dart main.dart
+web: ./dart-sdk/bin/dart main.dart


### PR DESCRIPTION
This pull request adds support for pub in the build process of Heroku.

**Issue**
As pub installs packages into the `$HOME` directory by default and since the `$HOME` folder in the build environment differs from the one in runtime, dart apps relying on pub would not work.

**Solution**
The packages need to be installed inside an separate folder in the cache folder and following the installation, the packages need to be copied to the build folder, maintaining the folder structure.

Additionally, in order to include and use packages residing within the dart-sdk, the whole `dart-sdk` folder needs to be moved into the build folder and pub needs to be called from that folder structure e.g. `/app/dart-sdk/bin/pub install` to maintain a correct symlink to the packages.

**Custom build versions**
Also included in this pull request is the ability to set an environmental variable called `BUILD` which takes a revision number from http://commondatastorage.googleapis.com/dart-editor-archive-integration/latest/changelog.html

This comes in handy when using libraries that are not working with the latest sdk version.

For more information, please feel free to contact me.

I hope this makes it easier for users to use dart on Heroku.

Matt
