### PR TITLE
Run build.dart if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is a Heroku buildpack for [Dart](http://www.dartlang.org/).
 
 Installation of packages through [pub](http://pub.dartlang.org/) is supported.
 
+A Dart build script (build.dart) will be executed if found.
+
 ## Getting Started
 
 ```bash

--- a/bin/compile
+++ b/bin/compile
@@ -75,5 +75,6 @@ cp -r $CACHE_DIR/pub-cache $BUILD_DIR/$PACKAGES_DIR
 # run Dart build script
 cd $BUILD_DIR
 if [ -e "build.dart" ]; then
+	message "-----> Run Dart build script (build.dart)"
 	/app/dart-sdk/bin/dart --package-root=packages/ build.dart
 fi


### PR DESCRIPTION
I've added a check for the presence of build.dart, which will be run at the end of the compile script.
