### PR TITLE
Fix all symlinks to packages dir after web_ui compilation

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -9,6 +9,7 @@ unset GIT_DIR
 mkdir -p "$1" "$2"
 BUILD_DIR=$(cd "$1/" && pwd)
 CACHE_DIR=$(cd "$2/" && pwd)
+BIN_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 # the directory in which the packages will be stored
 PACKAGES_DIR="tmp/repo.git/.cache"
@@ -52,7 +53,6 @@ cp -r $CACHE_DIR/dart-sdk /app
 message "-----> Install packages"
 
 cd $BUILD_DIR
-
 for filename in `find . -name pubspec.yaml | grep -v dart-sdk | grep -v pub-cache`; do
     pub_dir=`dirname $filename`
     message "*** Found pubspec.yaml in $pub_dir"
@@ -60,12 +60,6 @@ for filename in `find . -name pubspec.yaml | grep -v dart-sdk | grep -v pub-cach
 
     #start pub from the /app folder to have correct symlink paths
     /app/dart-sdk/bin/pub install
-
-    if [ -e $BUILD_DIR/$pub_dir/web/packages ]; then
-        cd $BUILD_DIR/$pub_dir/web
-        ln -sf ../packages
-        message "Fixed web symlink"
-    fi
 done
 
 # move packages from cache directory into build directory
@@ -74,7 +68,32 @@ cp -r $CACHE_DIR/pub-cache $BUILD_DIR/$PACKAGES_DIR
 
 # run Dart build script
 cd $BUILD_DIR
+export PATH=/app/dart-sdk/bin:$PATH
 if [ -e "build.dart" ]; then
 	message "-----> Run Dart build script (build.dart)"
-	/app/dart-sdk/bin/dart --package-root=packages/ build.dart
+	dart --package-root=packages/ build.dart
 fi
+
+# fix symlinks
+cd $BUILD_DIR
+for filename in `find . -name pubspec.yaml | grep -v dart-sdk | grep -v pub-cache`; do
+    pub_dir=`dirname $filename`
+    message "*** Fixing symlinks in in $pub_dir"
+    cd $BUILD_DIR/$pub_dir
+
+    for pdir in `find web -name packages -type l`; do
+        relpath=`$BIN_DIR/relpath "$( dirname "$pdir" )" "$BUILD_DIR/$pub_dir/packages"`
+        rm -f "$pdir"
+        ln -sf "$relpath" "$pdir"
+        target=`readlink "$pdir"`
+        if [ "$target" = "$relpath" ]
+        then
+            message "Fixed symlink $pdir -> $target"
+        else
+            message "Failed to fix $pdir -> $relpath"
+            message "Link: $pdir -> $target"
+            exit 1
+        fi
+    done
+done
+

--- a/bin/relpath
+++ b/bin/relpath
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# usage: relpath from to
+# see: http://stackoverflow.com/a/2565106/37416
+
+if [ -d "$1" ]
+then
+    D1="$( cd "$1" && pwd )"
+else
+    D1="$( cd "$( dirname "$1" )" && pwd )/$( basename "$1" )"
+fi
+
+if [ -d "$2" ]
+then
+    D2="$( cd "$2" && pwd )"
+else
+    D2="$( cd "$( dirname "$2" )" && pwd )/$( basename "$2" )"
+fi
+
+if [[ "$D1" == "$D2" ]]
+then
+    echo "."
+    exit
+fi
+
+IFS="/"
+
+current=($D1)
+absolute=($D2)
+
+abssize=${#absolute[@]}
+cursize=${#current[@]}
+
+while [[ ${absolute[level]} == ${current[level]} ]]
+do
+    (( level++ ))
+    if (( level > abssize || level > cursize ))
+    then
+        break
+    fi
+done
+
+for ((i = level; i < cursize; i++))
+do
+    if ((i > level))
+    then
+        newpath=$newpath"/"
+    fi
+    newpath=$newpath".."
+done
+
+for ((i = level; i < abssize; i++))
+do
+    if [[ -n $newpath ]]
+    then
+        newpath=$newpath"/"
+    fi
+    newpath=$newpath${absolute[i]}
+done
+
+echo "$newpath"


### PR DESCRIPTION
I've further extended the buildpack to include fixing all `packages` symlinks after build.dart is executed.

The `web/out` folder (at least) contains several links to `packages` after the web_ui compiler runs, and these need fixing up before the slug will work on Heroku.

I also have set the path to include the dart bin directory before `build.dart` is executed, since I run `dart2js` from my build.dart.

In the case where no `build.dart` is present, these changes should not affect the buildpack's behaviour, except to fix any extra links to `packages` if they are not at `web/packages`.
