### PR TITLE
Added support for *.deb and *.zip SDK URLs (for Cedar-14)

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,10 +11,7 @@ function message {
   sync
 }
 
-# Heroku stopped using the user-env-compile labs feature,
-# so let's use the new ENV_DIR feature.
-# Learn more here: https://devcenter.heroku.com/articles/buildpack-api
-
+# https://devcenter.heroku.com/articles/buildpack-api
 export_env_dir() {
   env_dir=$1
   message "-----> ENV_DIR is $env_dir"
@@ -54,7 +51,24 @@ cd $BUILD_DIR
 message "-----> Installing Dart VM via URL $DART_SDK_URL"
 
 cd $CACHE_DIR
-curl -L $DART_SDK_URL -o - | tar xzf -
+
+case "${DART_SDK_URL: -3}" in
+  tar)
+    message "SDK: tarball detected"
+    curl -L -k $DART_SDK_URL -o - | tar xzf -
+    ;;
+  zip)
+    message "SDK: zip detected"
+    curl -L -k $DART_SDK_URL > dart-sdk.zip ; unzip -o -q dart-sdk.zip
+    ;;
+  deb)
+    message "SDK: deb detected"
+    curl -L -k $DART_SDK_URL > dart-sdk.deb ; ar vx dart-sdk.deb ; tar xzf data.tar.gz
+    ;;
+  *)
+    message "Invalid Dart SDK URL" #kill after this or keep going in case SDK is there from last push?
+    ;;
+esac
 
 message "-----> Copy Dart binaries to app root"
 cp -r $CACHE_DIR/dart-sdk $BUILD_DIR


### PR DESCRIPTION
This adds the ability to also use Dart SDK urls that are built to .deb and .zip files. I am extracting the deb file manually instead of installing it right now to keep the process the same despite the extension. I think we can definitely build on this.

I tested with these three URLS:
*https://storage.googleapis.com/dart-archive/channels/stable/release/latest/linux_packages/debian_wheezy/dart_1.6.0-1_amd64.deb
*https://storage.googleapis.com/dart-archive/channels/stable/release/39553/sdk/dartsdk-linux-x64-release.zip
*https://github.com/selkhateeb/heroku-vagrant-dart-build/releases/download/1.2.0-dev.1.0/dart-sdk.tar

I think it can certainly be improved but this gets Cedar 14 support going without breaking anyone still using Ubuntu 10.x still. Right now it's looking at the extension from the URL but I think we should consider downloading the file and then figuring out the extension to account for redirects.

I noticed when I upgraded from 1.3 to 1.6, the sample basic_http_server app broke for some reason. I didn't figure out why, but I made a quick basic server app (using Redstone) and confirmed it was something in the code sample. My next PR will be a new basic test app.
