### PR TITLE
Provide dart-sdk dir in case of DART_SDK with ZIP

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -59,7 +59,7 @@ case "${DART_SDK_URL: -3}" in
     ;;
   zip)
     message "SDK: zip detected"
-    curl -L -k $DART_SDK_URL > dart-sdk.zip ; unzip -o -q dart-sdk.zip ; mv dart/dart-sdk dart-sdk
+    curl -L -k $DART_SDK_URL > dart-sdk.zip ; unzip -o -q dart-sdk.zip ; rm -rf dart-sdk ; mv dart/dart-sdk dart-sdk
     ;;
   deb)
     message "SDK: deb detected"


### PR DESCRIPTION
With the heroku-buildpack-dart current version and DART_SDK_URL=https://storage.googleapis.com/dart-archive/channels/stable/release/latest/editor/darteditor-linux-x64.zip

https://drone.io/github.com/GeReinhart/dart-gex-common-ui-elements/23
=> 
-----> Copy Dart binaries to app root
cp: cannot stat '/app/tmp/cache/dart-sdk': No such file or directory

 !     Push rejected, failed to compile Dart app

With the fix :
https://drone.io/github.com/GeReinhart/dart-gex-common-ui-elements/29

=> ...
-----> Launching... done, v11
       https://gex-common-ui-elements.herokuapp.com/ deployed to Heroku
