### PR TITLE
Only attempt to move dart-sdk folder if the full Dart Editor zip is used...

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -59,7 +59,15 @@ case "${DART_SDK_URL: -3}" in
     ;;
   zip)
     message "SDK: zip detected"
-    curl -L -k $DART_SDK_URL > dart-sdk.zip ; unzip -o -q dart-sdk.zip ; rm -rf dart-sdk ; mv dart/dart-sdk dart-sdk
+    curl -L -k $DART_SDK_URL > dart-sdk.zip
+    rm -rf dart
+    rm -rf dart-sdk
+    unzip -o -q dart-sdk.zip
+    if [ -d "dart" ]; then
+      # If for some reason you used the full Dart Editor zip
+      # we only need the dart-sdk directory
+      mv dart/dart-sdk $CACHE_DIR
+    fi
     ;;
   deb)
     message "SDK: deb detected"
@@ -67,7 +75,8 @@ case "${DART_SDK_URL: -3}" in
     message "Please use the .zip Dart SDK"
     ;;
   *)
-    message "Invalid Dart SDK URL" #kill after this or keep going in case SDK is there from last push?
+    message "Invalid Dart SDK URL"
+    # kill after this or keep going in case SDK is there from last push?
     ;;
 esac
 


### PR DESCRIPTION
This fixes #36 and restores functionality when using an SDK zip (as opposed to the Dart Editor + SDK zip).

Wrapped the case where someone might use the huge zip in a conditional. I'm not sure what the use-case is here... really should be only using just the SDK. Heroku also has issues with large repos and this could cause a problem there: https://devcenter.heroku.com/articles/git#repo-size (and Heroku throws warnings when you do this as well).
