### PR TITLE
Revert "Provide dart-sdk dir in case of DART_SDK with ZIP"

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -59,7 +59,7 @@ case "${DART_SDK_URL: -3}" in
     ;;
   zip)
     message "SDK: zip detected"
-    curl -L -k $DART_SDK_URL > dart-sdk.zip ; unzip -o -q dart-sdk.zip ; rm -rf dart-sdk ; mv dart/dart-sdk dart-sdk
+    curl -L -k $DART_SDK_URL > dart-sdk.zip ; unzip -o -q dart-sdk.zip
     ;;
   deb)
     message "SDK: deb detected"


### PR DESCRIPTION
This PR assumed something was broken when the wrong SDK URL was being used. It breaks everyone using the proper zip file.
