### PR TITLE
Skipping pub build if web directory not present

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -100,15 +100,19 @@ for filename in `find . -name pubspec.yaml | grep -v dart-sdk | grep -v pub-cach
     #start pub from the /app folder to have correct symlink paths
     /app/dart-sdk/bin/pub get
 
-    message "*** Running pub build"
-
-    if [[ -z "$DART_BUILD_CMD" ]]
+    if [ -d "web" ]
     then
-        message 'Building with "pub build"'
-        /app/dart-sdk/bin/pub build
+        message "*** Running pub build"
+        if [[ -z "$DART_BUILD_CMD" ]]
+        then
+            message 'Building with "pub build"'
+            /app/dart-sdk/bin/pub build
+        else
+            message "Building with \"$DART_BUILD_CMD\""
+            eval $DART_BUILD_CMD
+        fi
     else
-        message "Building with \"$DART_BUILD_CMD\""
-        eval $DART_BUILD_CMD
+        message '*** Skipping pub build because "web" folder not found'
     fi
 
 done


### PR DESCRIPTION
Not all Dart projects will have a "web" directory and require the `pub build` process.  This change will interpret the absence of that directory as a server only project and will skip pub build.