### PR TITLE
Allows global packages to be activated

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,22 @@ web: ./dart-sdk/bin/dart bin/basic_http_server.dart
 ### Overriding the build command
 
 By default `pub build` is launched after `pub get`, it can be useful to use
-another command: for instance `pub build --mode=debug` or 
+another command: for instance `pub build --mode=debug` or
 `/app/dart-sdk/bin/dart build.dart`:
 
 ```bash
 $> heroku config:set DART_BUILD_CMD="/app/dart-sdk/bin/dart build.dart"
 ```
 
-## Example 
+### Activating global packages
+
+You can activate global packages by providing the environment variable `DART_GLOBAL_PACKAGES`. Each globally activated package is space delimited and takes the form of `package_name@1.0.0`:
+
+```bash
+$> heroku config:set DART_GLOBAL_PACKAGES="aqueduct@3.0.0"
+```
+
+## Example
 
 See `test-app` directory for the world simplest Dart web app running on
 Heroku.

--- a/bin/compile
+++ b/bin/compile
@@ -118,7 +118,7 @@ for filename in `find . -name pubspec.yaml | grep -v dart-sdk | grep -v pub-cach
     for package in $DART_GLOBAL_PACKAGES
     do
         PACKAGE_ELEMENTS=(${package//@/ })
-        pub global activate "${PACKAGE_ELEMENTS[0]}" "${PACKAGE_ELEMENTS[1]}"
+        /app/dart-sdk/bin/pub global activate "${PACKAGE_ELEMENTS[0]}" "${PACKAGE_ELEMENTS[1]}"
     done
 done
 

--- a/bin/compile
+++ b/bin/compile
@@ -115,6 +115,13 @@ for filename in `find . -name pubspec.yaml | grep -v dart-sdk | grep -v pub-cach
         message '*** Skipping pub build because "web" folder not found'
     fi
 
+    AQUEDUCT_DEP=`cat .packages | grep ^aqueduct`
+    if [ ${#AQUEDUCT_DEP} -ne 0 ]; then
+      AQ_LIB_PATH=${AQUEDUCT_DEP:16}
+      AQ_PATH=`dirname $AQ_LIB_PATH`
+      /app/dart-sdk/bin/pub global activate -spath $AQ_PATH
+    fi
+
 done
 
 # I think heroku deletes all the contents of /app and replaces it with

--- a/bin/compile
+++ b/bin/compile
@@ -115,13 +115,11 @@ for filename in `find . -name pubspec.yaml | grep -v dart-sdk | grep -v pub-cach
         message '*** Skipping pub build because "web" folder not found'
     fi
 
-    AQUEDUCT_DEP=`cat .packages | grep ^aqueduct`
-    if [ ${#AQUEDUCT_DEP} -ne 0 ]; then
-      AQ_LIB_PATH=${AQUEDUCT_DEP:16}
-      AQ_PATH=`dirname $AQ_LIB_PATH`
-      /app/dart-sdk/bin/pub global activate -spath $AQ_PATH
-    fi
-
+    for package in $DART_GLOBAL_PACKAGES
+    do
+        PACKAGE_ELEMENTS=(${package//@/ })
+        pub global activate "${PACKAGE_ELEMENTS[0]}" "${PACKAGE_ELEMENTS[1]}"
+    done
 done
 
 # I think heroku deletes all the contents of /app and replaces it with


### PR DESCRIPTION
Set DART_GLOBAL_PACKAGES environment variable to a space-delimited list of `package_name@version`. This will `pub global activate` each package at that version during the build step.