### PR TITLE
Update compile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -40,7 +40,7 @@ build_pubspec() {
   export PATH=$PATH:$DART_PATH:$PUB_CACHE_BIN
   message "*** Running pub get"
 
-  pub --version
+  dart --version
 
   #start pub from the /app folder to have correct symlink paths
   pub get  


### PR DESCRIPTION
Dart SDK'nın daha yeni sürümlerinde pub komutu dart pub olarak çalıştırılmaktadır. Bu nedenle, Heroku buildpack'inizin pub komutunu doğru bir şekilde çağırdığından emin olmanız gerekiyor.